### PR TITLE
Add systemd activation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,23 @@ To test manually you can run:
 ```
 
 Ensure your SMTP settings in `send_wazuh_mail.c` match your environment.
+
+## Enabling the service
+
+To run the mail notifier automatically, install one of the provided systemd
+unit files and enable it:
+
+```bash
+# For the Python implementation
+sudo ln -s /opt/wazuh-mail/python_version/wazuh-mail.service /etc/systemd/system/wazuh-mail.service
+# Or for the C implementation
+sudo ln -s /opt/wazuh-mail/c_version/wazuh-mail-c.service /etc/systemd/system/wazuh-mail-c.service
+
+sudo systemctl daemon-reload
+sudo systemctl enable wazuh-mail.service    # or wazuh-mail-c.service
+sudo systemctl start wazuh-mail.service     # or wazuh-mail-c.service
+```
+
+The service expects the program files to be located in `/opt/wazuh-mail` as
+referenced in the unit files. Adjust the paths if you deploy the scripts
+elsewhere.


### PR DESCRIPTION
## Summary
- document how to enable wazuh-mail service in README
- use symbolic links for unit files instead of copying

## Testing
- `make -C c_version clean all`
- `python3 -m py_compile python_version/send_wazuh_mail.py`


------
https://chatgpt.com/codex/tasks/task_e_6851347bb95c83218138dbfdb02eed1c